### PR TITLE
fix: chat_page와 관련 데이터 구조에서 불필요한 chatId 삭제

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1268,6 +1268,9 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
   - Flutter (1.0.0)
+  - flutter_naver_map (1.3.1):
+    - Flutter
+    - NMapsMap (= 3.21.0)
   - GoogleUtilities/AppDelegateSwizzler (8.0.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -1382,12 +1385,20 @@ PODS:
   - gRPC-Core/Interface (1.69.0)
   - gRPC-Core/Privacy (1.69.0)
   - GTMSessionFetcher/Core (4.4.0)
+  - image_picker_ios (0.0.1):
+    - Flutter
   - leveldb-library (1.22.6)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
+  - NMapsGeometry (1.0.2)
+  - NMapsMap (3.21.0):
+    - NMapsGeometry
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - RecaptchaInterop (101.0.0)
 
 DEPENDENCIES:
@@ -1396,6 +1407,9 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
   - Flutter (from `Flutter`)
+  - flutter_naver_map (from `.symlinks/plugins/flutter_naver_map/ios`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -1418,6 +1432,8 @@ SPEC REPOS:
     - GTMSessionFetcher
     - leveldb-library
     - nanopb
+    - NMapsGeometry
+    - NMapsMap
     - RecaptchaInterop
 
 EXTERNAL SOURCES:
@@ -1431,6 +1447,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_storage/ios"
   Flutter:
     :path: Flutter
+  flutter_naver_map:
+    :path: ".symlinks/plugins/flutter_naver_map/ios"
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
 
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
@@ -1451,12 +1473,17 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: b1d32c3b29a911dc174bcf363f2f70bda9509d2f
   FirebaseStorage: e83d1b9c8a5318d46ccfb2955f0d98095e0bf598
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_naver_map: efcc30f2bb0eaacdb14f41b5a26696b3ca1e3319
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   "gRPC-C++": cc207623316fb041a7a3e774c252cf68a058b9e8
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMSessionFetcher: 75b671f9e551e4c49153d4c4f8659ef4f559b970
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  NMapsGeometry: 4e02554fa9880ef02ed96b075dc84355d6352479
+  NMapsMap: 8e7e35c2446e7c4a88d6dd0d64aa0d1de903e4f0
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
 
 PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -5,12 +5,10 @@ import '../providers/chat_providers.dart';
 
 class ChatPage extends ConsumerStatefulWidget {
   final String markerId;
-  final String chatId;
 
   const ChatPage({
     super.key,
     required this.markerId,
-    required this.chatId,
   });
 
   @override
@@ -56,7 +54,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
   @override
   Widget build(BuildContext context) {
     print('ChatPage build called');
-    final params = ChatParams(widget.markerId, widget.chatId);
+    final params = ChatParams(widget.markerId);
     final messages = ref.watch(chatNotifierProvider(params));
     final chatAsync = ref.watch(chatProvider(params));
 

--- a/lib/providers/chat_providers.dart
+++ b/lib/providers/chat_providers.dart
@@ -3,30 +3,28 @@ import '../models/chat.dart';
 import '../models/message.dart';
 import '../repository/chat_repository.dart';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 class ChatParams {
   final String markerId;
-  final String chatId;
 
-  ChatParams(this.markerId, this.chatId);
+  ChatParams(this.markerId);
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is ChatParams &&
-              markerId == other.markerId &&
-              chatId == other.chatId;
+          other is ChatParams && markerId == other.markerId;
 
   @override
-  int get hashCode => markerId.hashCode ^ chatId.hashCode;
+  int get hashCode => markerId.hashCode;
 }
 
 class ChatNotifier extends StateNotifier<List<Message>> {
   final ChatRepository _repository;
   final String markerId;
-  final String chatId;
   Chat? _chat;
 
-  ChatNotifier(this._repository, this.markerId, this.chatId) : super([]) {
+  ChatNotifier(this._repository, this.markerId) : super([]) {
     _loadData();
   }
 
@@ -34,8 +32,8 @@ class ChatNotifier extends StateNotifier<List<Message>> {
 
   Future<void> _loadData() async {
     try {
-      _chat = await _repository.getChat(markerId, chatId);
-      state = await _repository.getMessages(markerId, chatId);
+      _chat = await _repository.getChat(markerId);
+      state = await _repository.getMessages(markerId);
       print('Chat loaded: ${_chat?.title}, Messages: ${state.length}');
     } catch (e) {
       print('Error loading data: $e');
@@ -53,7 +51,7 @@ class ChatNotifier extends StateNotifier<List<Message>> {
         timestamp: DateTime.now(),
         readBy: [senderId],
       );
-      await _repository.sendMessage(markerId, chatId, newMessage);
+      await _repository.sendMessage(markerId, newMessage);
       state = [...state, newMessage];
       print('Message sent: ${newMessage.message}');
     } catch (e) {
@@ -67,11 +65,11 @@ final chatRepositoryProvider = Provider((ref) => ChatRepository());
 final chatNotifierProvider = StateNotifierProvider.family<ChatNotifier, List<Message>, ChatParams>(
       (ref, params) {
     final repository = ref.watch(chatRepositoryProvider);
-    return ChatNotifier(repository, params.markerId, params.chatId);
+    return ChatNotifier(repository, params.markerId);
   },
 );
 
 final chatProvider = FutureProvider.family<Chat?, ChatParams>((ref, params) async {
   final repository = ref.watch(chatRepositoryProvider);
-  return await repository.getChat(params.markerId, params.chatId);
+  return await repository.getChat(params.markerId);
 });

--- a/lib/repository/chat_repository.dart
+++ b/lib/repository/chat_repository.dart
@@ -3,17 +3,17 @@ import '../models/dummy_data_for_chat_page.dart';
 import '../models/message.dart';
 
 class ChatRepository {
-  Future<Chat> getChat(String markerId, String chatId) async {
+  Future<Chat> getChat(String markerId) async {
     // 더미 데이터 반환 (실제로는 Firebase에서 가져옴)
-    if (markerId == 'marker001' && chatId == 'chat001') {
+    if (markerId == 'marker001') {
       return dummyChat;
     }
-    throw Exception('Chat not found for markerId: $markerId, chatId: $chatId');
+    throw Exception('Chat not found for markerId: $markerId');
   }
 
-  Future<List<Message>> getMessages(String markerId, String chatId) async {
-    print('getMessages called with markerId: $markerId, chatId: $chatId');
-    if (markerId == 'marker001' && chatId == 'chat001') {
+  Future<List<Message>> getMessages(String markerId) async {
+    print('getMessages called with markerId: $markerId');
+    if (markerId == 'marker001') {
       print('Returning dummyMessages: ${dummyMessages.length} messages');
       return dummyMessages;
     }
@@ -21,9 +21,9 @@ class ChatRepository {
     return [];
   }
 
-  Future<void> sendMessage(String markerId, String chatId, Message message) async {
+  Future<void> sendMessage(String markerId, Message message) async {
     // 더미 데이터에 메시지 추가 (실제로는 Firebase에 저장)
-    if (markerId == 'marker001' && chatId == 'chat001') {
+    if (markerId == 'marker001') {
       dummyMessages.add(message);
     }
   }


### PR DESCRIPTION
markerId당 채팅방은 1개이니 굳이 chatId가 있을 필요가 없습니다. 또한 웰컴 페이지에서 마커를 클릭했을 때 해당 마커의 id만으로 채팅방으로 이동할 수 있으려면 삭제해야 하므로 데이터 구조에서 삭제했습니다.